### PR TITLE
persist the previously-chosen color

### DIFF
--- a/white_board.py
+++ b/white_board.py
@@ -19,7 +19,7 @@ def stop_drawing(event):
 
 def change_pen_color():
     global drawing_color
-    color = askcolor()[1]
+    color = askcolor(drawing_color)[1]
     if color:
         drawing_color = color
 


### PR DESCRIPTION
this way the previously-chosen color is preserved rather than resorting to the default gray color that the picker uses